### PR TITLE
fix(ApplePay): fix controller unavailable error on iOS 26

### DIFF
--- a/Sources/RozetkaPaySDK/Configuration/ApplePayConfig.swift
+++ b/Sources/RozetkaPaySDK/Configuration/ApplePayConfig.swift
@@ -40,7 +40,7 @@ public class ApplePayConfig {
     ///   - merchantIdentifier: Your Apple Pay merchant ID.
     ///   - merchantName: The merchant name displayed in the payment sheet.
     ///   - supportedNetworks: Optional list of card networks. Defaults to Visa and MasterCard.
-    ///   - merchantCapabilities: Optional capabilities. Defaults to `.capability3DS`.
+    ///   - merchantCapabilities: Optional capabilities. Defaults to `[.capability3DS, .capabilityDebit, .capabilityCredit]`.
     ///   - currencyCode: Optional currency code. Defaults to `RozetkaPayConfig.defaultCurrencyCode`.
     ///   - countryCode: Optional country code. Defaults to `RozetkaPayConfig.defaultCountryCode`.
     init(
@@ -54,7 +54,13 @@ public class ApplePayConfig {
         self.merchantIdentifier = merchantIdentifier
         self.merchantName = merchantName
         self.supportedNetworks = supportedNetworks ?? [.visa, .masterCard]
-        self.merchantCapabilities = merchantCapabilities ?? .capability3DS
+        
+        if #available(iOS 17.0, *) {
+            self.merchantCapabilities = merchantCapabilities ?? [.threeDSecure, .debit, .credit]
+        } else {
+            self.merchantCapabilities = merchantCapabilities ?? [.capability3DS, .capabilityDebit, .capabilityCredit]
+        }
+        
         self.countryCode = countryCode ?? RozetkaPayConfig.defaultCountryCode
         self.currencyCode = currencyCode ?? RozetkaPayConfig.defaultCurrencyCode
     }
@@ -62,15 +68,19 @@ public class ApplePayConfig {
     /// Test configuration for sandbox Apple Pay.
     public class Test: ApplePayConfig {
         /// Initializes a test config with default merchant name.
-        public init(
+        public override init(
             merchantIdentifier: String,
             merchantName: String = "RozetkaPay Test Merchant",
+            supportedNetworks: [PKPaymentNetwork]? = nil,
+            merchantCapabilities: PKMerchantCapability? = nil,
             currencyCode: String? = nil,
             countryCode: String? = nil
         ) {
             super.init(
                 merchantIdentifier: merchantIdentifier,
                 merchantName: merchantName,
+                supportedNetworks: supportedNetworks,
+                merchantCapabilities: merchantCapabilities,
                 currencyCode: currencyCode,
                 countryCode: countryCode
             )
@@ -80,11 +90,11 @@ public class ApplePayConfig {
     /// Production configuration for live Apple Pay.
     public class Production: ApplePayConfig {
         /// Initializes a production config with required merchant info.
-        public init(
+        public override init(
             merchantIdentifier: String,
             merchantName: String,
-            supportedNetworks: [PKPaymentNetwork] = [.visa, .masterCard],
-            merchantCapabilities: PKMerchantCapability = .capability3DS,
+            supportedNetworks: [PKPaymentNetwork]? = nil,
+            merchantCapabilities: PKMerchantCapability? = nil,
             currencyCode: String? = nil,
             countryCode: String? = nil
         ) {
@@ -102,13 +112,16 @@ public class ApplePayConfig {
     /// Checks whether Apple Pay is available and configured correctly on the device.
     ///
     /// Logs detailed messages using `Logger.payByApplePay`.
-    /// - Returns: `true` if Apple Pay is available and supports the configured networks; otherwise, `false`.
+    /// - Returns: `true` if Apple Pay is available and supports the configured networks and capabilities; otherwise, `false`.
     func checkApplePayAvailability() -> Bool {
         if PKPaymentAuthorizationController.canMakePayments() {
             Logger.payByApplePay.info("🍏 Apple Pay is available on this device. 🍏")
             
-            if PKPaymentAuthorizationController.canMakePayments(usingNetworks: supportedNetworks) {
-                Logger.payByApplePay.info("Apple Pay supports payment networks: [\(supportedNetworks.debugDescription)].")
+            if PKPaymentAuthorizationController.canMakePayments(
+                usingNetworks: supportedNetworks,
+                capabilities: merchantCapabilities
+            ) {
+                Logger.payByApplePay.info("Apple Pay supports payment networks: [\(supportedNetworks.debugDescription)], capabilities: [\(merchantCapabilities.debugDescription)]")
                 return true
             } else {
                 Logger.payByApplePay.warning("⚠️ Apple Pay is available but doesn't support these networks: [\(supportedNetworks.debugDescription)].")

--- a/Sources/RozetkaPaySDK/Extensions/PKMerchantCapabilityExtensions.swift
+++ b/Sources/RozetkaPaySDK/Extensions/PKMerchantCapabilityExtensions.swift
@@ -1,0 +1,30 @@
+//
+//  File.swift
+//  RozetkaPaySDK
+//
+//  Created by Ruslan Kasian Dev on 16.01.2026.
+//
+
+import Foundation
+import PassKit
+
+extension PKMerchantCapability: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        var capabilities: [String] = []
+        
+        if #available(iOS 17.0, *) {
+            if contains(.threeDSecure) { capabilities.append("3DS") }
+            if contains(.debit) { capabilities.append("Debit") }
+            if contains(.credit) { capabilities.append("Credit") }
+            if contains(.emv) { capabilities.append("EMV") }
+            if contains(.instantFundsOut) { capabilities.append("InstantFundsOut") }
+        } else {
+            if contains(.capability3DS) { capabilities.append("3DS") }
+            if contains(.capabilityDebit) { capabilities.append("Debit") }
+            if contains(.capabilityCredit) { capabilities.append("Credit") }
+            if contains(.capabilityEMV) { capabilities.append("EMV") }
+        }
+        
+        return capabilities.isEmpty ? "none" : capabilities.joined(separator: ", ")
+    }
+}

--- a/Sources/RozetkaPaySDK/Helpers/MoneyFormatter.swift
+++ b/Sources/RozetkaPaySDK/Helpers/MoneyFormatter.swift
@@ -112,6 +112,7 @@ public final class MoneyFormatter {
     /// - Returns: A configured `NumberFormatter`.
     private static func generateFormatter(for exponent: Int, usesGroupingSeparator: Bool) -> NumberFormatter {
         let formatter = NumberFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.numberStyle = .decimal
         formatter.groupingSeparator = usesGroupingSeparator ? " " : ""
         formatter.decimalSeparator = String(decimalSeparator)

--- a/Sources/RozetkaPaySDK/Services/ApplePaymentService.swift
+++ b/Sources/RozetkaPaySDK/Services/ApplePaymentService.swift
@@ -40,6 +40,23 @@ final class ApplePaymentService: NSObject {
 extension ApplePaymentService {
     
     func startPayment(onResultCallback: @escaping ApplePaymentCompletionHandler) {
+        
+        self.onResultCallback = onResultCallback
+        guard config.checkApplePayAvailability() else {
+            
+            let paymentError = PaymentError(
+                code: ErrorResponseCode.applePayUnavailable.rawValue,
+                message: "Apple Pay is not available on this device.",
+                externalId: self.externalId,
+                type: ErrorResponseType.paymentError.rawValue
+            )
+            
+            self.onResultCallback?(
+                .failed(error: paymentError)
+            )
+            return
+        }
+        
         paymentSummaryItems.removeAll()
         let amount = PKPaymentSummaryItem(
             label: Localization.rozetka_pay_payment_applepay_label_amount.description,
@@ -74,26 +91,30 @@ extension ApplePaymentService {
         
         self.paymentController = PKPaymentAuthorizationController(paymentRequest: paymentRequest)
         self.paymentController?.delegate = self
-        self.onResultCallback = onResultCallback
         
-        self.paymentController?.present(completion: { (presented: Bool) in
-            if presented {
-                Logger.payByApplePay.info("✅ Presented Apple Pay payment controller")
-            } else {
-                Logger.payByApplePay.warning("⚠️ WARNING: Apple Pay payment controller unavailable")
-                
-                let paymentError = PaymentError(
-                    code: ErrorResponseCode.applePayUnavailable.rawValue,
-                    message: "Apple Pay payment controller unavailable",
-                    externalId: self.externalId,
-                    type: ErrorResponseType.paymentError.rawValue
-                )
-                
-                self.onResultCallback?(
-                    .failed(error: paymentError)
-                )
+        DispatchQueue.main.async { [weak self] in
+            guard let self else {
+                return
             }
-        })
+            self.paymentController?.present { presented in
+                if presented {
+                    Logger.payByApplePay.info("✅ Presented Apple Pay payment controller")
+                } else {
+                    Logger.payByApplePay.warning("⚠️ WARNING: Apple Pay payment controller unavailable")
+                    
+                    let paymentError = PaymentError(
+                        code: ErrorResponseCode.applePayUnavailable.rawValue,
+                        message: "Apple Pay payment controller unavailable",
+                        externalId: self.externalId,
+                        type: ErrorResponseType.paymentError.rawValue
+                    )
+                    
+                    self.onResultCallback?(
+                        .failed(error: paymentError)
+                    )
+                }
+            }
+        }
     }
     
     
@@ -113,7 +134,7 @@ extension ApplePaymentService {
         }
         
         Logger.payByApplePay.debug("✅ Apple Pay token successfully encoded: \(base64Token.prefix(5))... to Base64")
-      
+        
         return base64Token
     }
     


### PR DESCRIPTION
- Add default merchantCapabilities
- Fix MoneyFormatter locale for consistent decimal formatting
- Ensure paymentController presentation runs on main thread