### PR TITLE
Fix Apple Pay total summary item label

### DIFF
--- a/Sources/Resources/Localizable.xcstrings
+++ b/Sources/Resources/Localizable.xcstrings
@@ -403,7 +403,7 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Неправильне значення дати закінчення терміну дії"
           }
         }
@@ -490,23 +490,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Податок"
-          }
-        }
-      }
-    },
-    "rozetka_pay_payment_applepay_label_total" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Total"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Всього"
           }
         }
       }

--- a/Sources/RozetkaPaySDK/Services/ApplePaymentService.swift
+++ b/Sources/RozetkaPaySDK/Services/ApplePaymentService.swift
@@ -74,7 +74,7 @@ extension ApplePaymentService {
             paymentSummaryItems.append(tax)
         }
         let total = PKPaymentSummaryItem(
-            label: Localization.rozetka_pay_payment_applepay_label_total.description,
+            label: config.merchantName,
             amount: NSDecimalNumber(string: MoneyFormatter.formatCoinsToRawMoneyString(coins: amountParameters.total)),
             type: .final
         )

--- a/Sources/RozetkaPaySDK/Services/Localization.swift
+++ b/Sources/RozetkaPaySDK/Services/Localization.swift
@@ -35,7 +35,6 @@ public enum Localization: String {
     
     case rozetka_pay_payment_applepay_label_amount
     case rozetka_pay_payment_applepay_label_tax
-    case rozetka_pay_payment_applepay_label_total
     
     
     case rozetka_pay_form_card_info_title


### PR DESCRIPTION
Updated the Apple Pay payment summary to use the merchant name as the label for the final PKPaymentSummaryItem, aligning with Apple Pay guidelines.