### PR TITLE
change retry/cancel behavior in Tokenization Form

### DIFF
--- a/Sources/RozetkaPaySDK/ViewModel/BaseViewModel.swift
+++ b/Sources/RozetkaPaySDK/ViewModel/BaseViewModel.swift
@@ -163,6 +163,26 @@ class BaseViewModel: ObservableObject {
         }
     }
     
+    func clearFormFields() {
+        DispatchQueue.main.async {
+            self.cardNumber = nil
+            self.cvv = nil
+            self.expiryDate = nil
+            self.cardName = nil
+            self.cardholderName = nil
+            self.email = nil
+            
+            self.cardNumberStatus = .none
+            self.cvvStatus = .none
+            self.expiryDateStatus = .none
+            self.cardNameStatus = .none
+            self.cardholderNameStatus = .none
+            self.emailStatus = .none
+            
+            self.didPerformInitialValidation = false
+        }
+    }
+    
     func setTestData() {
         #warning("MOC DATA")
 //    #if DEBUG

--- a/Sources/RozetkaPaySDK/ViewModel/TokenizationFormViewModel.swift
+++ b/Sources/RozetkaPaySDK/ViewModel/TokenizationFormViewModel.swift
@@ -53,12 +53,20 @@ extension TokenizationFormViewModel {
     }
     
     func retryLoading() {
-        startLoading()
+        resetState()
+        stopLoader()
+        stateUICallback?(
+            .stopLoading
+        )
     }
     
     func cancelled() {
+        clearFormFields()
         resetState()
         stopLoader()
+        stateUICallback?(
+            .stopLoading
+        )
         
         onResultCallback?(
             .cancelled


### PR DESCRIPTION
Aligned iOS retry/cancel behavior with android after feedback. "Retry" now returns to the form with pre-filled data instead of re-submitting immediately. "Cancel" clears all form fields before returning to the empty form. Added clearFormFields() method to BaseViewModel.