### PR TITLE
feat(RozetkaPaySDK): deliver .failed on error dismiss

### DIFF
--- a/Sources/Resources/Localizable.xcstrings
+++ b/Sources/Resources/Localizable.xcstrings
@@ -18,6 +18,23 @@
         }
       }
     },
+    "rozetka_pay_common_button_close" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закрити"
+          }
+        }
+      }
+    },
     "rozetka_pay_common_button_done" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Sources/RozetkaPaySDK/Models/BatchPayment/BatchPaymentParameters.swift
+++ b/Sources/RozetkaPaySDK/Models/BatchPayment/BatchPaymentParameters.swift
@@ -43,7 +43,10 @@ public struct BatchPaymentParameters: ParametersProtocol {
     
     /// List of orders to be paid in the batch.
     let orders: [BatchOrder]
-    
+
+    /// Title shown on the dismiss button of the error screen. Defaults to `.close`.
+    let errorDismissButtonTitle: ErrorDismissButtonTitle
+
     /// Creates a new instance of `PaymentParameters`.
     public init(
         client: ClientAuthParameters,
@@ -54,7 +57,8 @@ public struct BatchPaymentParameters: ParametersProtocol {
         amountParameters: AmountParameters,
         externalId: String,
         callbackUrl: String? = nil,
-        orders: [BatchOrder]
+        orders: [BatchOrder],
+        errorDismissButtonTitle: ErrorDismissButtonTitle = .close
     ) {
         self.client = client
         self.themeConfigurator = themeConfigurator
@@ -64,6 +68,7 @@ public struct BatchPaymentParameters: ParametersProtocol {
         self.callbackUrl = callbackUrl
         self.resultUrl = EnvironmentProvider.environment.paymentsConfirmation3DsCallbackUrl
         self.orders = orders
+        self.errorDismissButtonTitle = errorDismissButtonTitle
     }
     
     var applePaymentService: ApplePaymentService? {

--- a/Sources/RozetkaPaySDK/Models/ErrorDismissButtonTitle.swift
+++ b/Sources/RozetkaPaySDK/Models/ErrorDismissButtonTitle.swift
@@ -1,0 +1,30 @@
+//
+//  ErrorDismissButtonTitle.swift
+//  RozetkaPaySDK
+//
+//  Created by Ruslan Kasian Dev on 30.06.2026.
+//
+import Foundation
+
+/// Title shown on the dismiss button of the error screen.
+///
+/// Lets host apps choose the wording that fits their UX. The button always
+/// delivers a `.failed` result regardless of the chosen title — only the
+/// label differs.
+public enum ErrorDismissButtonTitle {
+    case cancel
+    case close
+    case custom(String)
+
+    var title: String {
+        switch self {
+        case .custom(let title):
+            return title
+        case .cancel:
+            return Localization.rozetka_pay_common_button_cancel.description
+        case .close:
+            return Localization.rozetka_pay_common_button_close.description
+        }
+       
+    }
+}

--- a/Sources/RozetkaPaySDK/Models/Errors/TokenizationError.swift
+++ b/Sources/RozetkaPaySDK/Models/Errors/TokenizationError.swift
@@ -110,4 +110,25 @@ extension TokenizationError {
             return .failed(error: errorModel)
         }
     }
+
+    func convertToCreateBatchPaymentResult(_ batchExternalId: String) -> CreateBatchPaymentResult {
+        switch self {
+        case .cancelled:
+            return .cancelled(batchExternalId: batchExternalId)
+        case let .failed(message, errorDescription):
+            let errorModel = PaymentError(
+                code: ErrorResponseCode.failedToVerifyCard.rawValue,
+                message: message,
+                externalId: batchExternalId,
+                paymentId: nil,
+                type: ErrorResponseType.paymentError.rawValue,
+                errorDescription: errorDescription
+            )
+
+            return .failed(
+                batchExternalId: batchExternalId,
+                error: errorModel
+            )
+        }
+    }
 }

--- a/Sources/RozetkaPaySDK/Models/Payment/PaymentParameters.swift
+++ b/Sources/RozetkaPaySDK/Models/Payment/PaymentParameters.swift
@@ -38,7 +38,10 @@ public struct PaymentParameters: ParametersProtocol {
     
     /// Optional URL that will be called after the payment is finished.
     let resultUrl: String?
-    
+
+    /// Title shown on the dismiss button of the error screen. Defaults to `.close`.
+    let errorDismissButtonTitle: ErrorDismissButtonTitle
+
     /// Creates a new instance of `PaymentParameters`.
     public init(
         client: ClientAuthParameters,
@@ -48,7 +51,8 @@ public struct PaymentParameters: ParametersProtocol {
         ),
         amountParameters: AmountParameters,
         externalId: String,
-        callbackUrl: String? = nil
+        callbackUrl: String? = nil,
+        errorDismissButtonTitle: ErrorDismissButtonTitle = .close
     ) {
         self.client = client
         self.themeConfigurator = themeConfigurator
@@ -57,6 +61,7 @@ public struct PaymentParameters: ParametersProtocol {
         self.externalId = externalId
         self.callbackUrl = callbackUrl
         self.resultUrl = EnvironmentProvider.environment.paymentsConfirmation3DsCallbackUrl
+        self.errorDismissButtonTitle = errorDismissButtonTitle
     }
     
     var applePaymentService: ApplePaymentService? {

--- a/Sources/RozetkaPaySDK/Models/Tokenization/TokenizationFormParameters.swift
+++ b/Sources/RozetkaPaySDK/Models/Tokenization/TokenizationFormParameters.swift
@@ -7,17 +7,26 @@
 import Foundation
 
 public struct TokenizationFormParameters: ParametersProtocol {
+    /// Client authentication parameters.
     public let client: ClientAuthParametersProtocol
+    
     public let viewParameters: ViewParametersProtocol
+    
+    /// Theme configuration for the payment UI.
     public let themeConfigurator: RozetkaPayThemeConfigurator
     
+    /// Title shown on the dismiss button of the error screen. Defaults to `.cancel`.
+    let errorDismissButtonTitle: ErrorDismissButtonTitle
+
     public init(
         client: ClientWidgetParameters,
         viewParameters: TokenizationFormViewParameters = TokenizationFormViewParameters(),
-        themeConfigurator: RozetkaPayThemeConfigurator = RozetkaPayThemeConfigurator()
+        themeConfigurator: RozetkaPayThemeConfigurator = RozetkaPayThemeConfigurator(),
+        errorDismissButtonTitle: ErrorDismissButtonTitle = .cancel
     ) {
         self.client = client
         self.viewParameters = viewParameters
         self.themeConfigurator = themeConfigurator
+        self.errorDismissButtonTitle = errorDismissButtonTitle
     }
 }

--- a/Sources/RozetkaPaySDK/Models/Tokenization/TokenizationParameters.swift
+++ b/Sources/RozetkaPaySDK/Models/Tokenization/TokenizationParameters.swift
@@ -8,17 +8,26 @@
 import Foundation
 
 public struct TokenizationParameters: ParametersProtocol {
+    /// Client authentication parameters.
     public let client: ClientAuthParametersProtocol
+    
     public let viewParameters: ViewParametersProtocol
+    
+    /// Theme configuration for the payment UI.
     public let themeConfigurator: RozetkaPayThemeConfigurator
     
+    /// Title shown on the dismiss button of the error screen. Defaults to `.close`.
+    let errorDismissButtonTitle: ErrorDismissButtonTitle
+
     public init(
         client: ClientWidgetParameters,
         viewParameters: TokenizationViewParameters = TokenizationViewParameters(),
-        themeConfigurator: RozetkaPayThemeConfigurator = RozetkaPayThemeConfigurator()
+        themeConfigurator: RozetkaPayThemeConfigurator = RozetkaPayThemeConfigurator(),
+        errorDismissButtonTitle: ErrorDismissButtonTitle = .close
     ) {
         self.client = client
         self.viewParameters = viewParameters
         self.themeConfigurator = themeConfigurator
+        self.errorDismissButtonTitle = errorDismissButtonTitle
     }
 }

--- a/Sources/RozetkaPaySDK/Services/Localization.swift
+++ b/Sources/RozetkaPaySDK/Services/Localization.swift
@@ -13,6 +13,7 @@ public enum Localization: String {
     case rozetka_pay_common_loading_message
     case rozetka_pay_common_error_message
     case rozetka_pay_common_button_cancel
+    case rozetka_pay_common_button_close
     case rozetka_pay_common_button_retry
     case rozetka_pay_common_button_done
     

--- a/Sources/RozetkaPaySDK/View/ErrorView.swift
+++ b/Sources/RozetkaPaySDK/View/ErrorView.swift
@@ -15,6 +15,7 @@ struct ErrorView: View {
     private var errorMessage: String
     private var onCancel: () -> Void
     private var onRetry: () -> Void
+    private var cancelButtonTitle: String
     private var isButtonRetryEnabled: Bool
     private var isExpanded: Bool
     private let accessibilityNamespace: String
@@ -29,6 +30,7 @@ struct ErrorView: View {
         errorMessage: String? = nil,
         onCancel: @escaping () -> Void,
         onRetry: @escaping () -> Void = {},
+        cancelButtonTitle: String? = nil,
         isButtonRetryEnabled: Bool = true,
         isExpanded: Bool = false
     ) {
@@ -37,6 +39,7 @@ struct ErrorView: View {
         self.errorMessage = errorMessage ?? Localization.rozetka_pay_tokenization_error_common.description
         self.onCancel = onCancel
         self.onRetry = onRetry
+        self.cancelButtonTitle = cancelButtonTitle ?? Localization.rozetka_pay_common_button_cancel.description
         self.isButtonRetryEnabled = isButtonRetryEnabled
         self.isExpanded = isExpanded
     }
@@ -161,7 +164,7 @@ private extension ErrorView {
         }) {
             Text(isButtonRetryEnabled ?
                  Localization.rozetka_pay_common_button_retry.description :
-                    Localization.rozetka_pay_common_button_cancel.description
+                    cancelButtonTitle
             )
             .font(
                 themeConfigurator
@@ -202,7 +205,7 @@ private extension ErrorView {
         Button(action: {
             onCancel()
         }) {
-            Text(Localization.rozetka_pay_common_button_cancel.description
+            Text(cancelButtonTitle
             )
             .font(
                 themeConfigurator

--- a/Sources/RozetkaPaySDK/View/PayView.swift
+++ b/Sources/RozetkaPaySDK/View/PayView.swift
@@ -133,11 +133,12 @@ private extension PayView {
             themeConfigurator: viewModel.themeConfigurator,
             errorMessage: viewModel.errorMessage,
             onCancel: {
-                viewModel.cancelled()
+                viewModel.failed()
             },
             onRetry: {
                 viewModel.retryLoading()
             },
+            cancelButtonTitle: viewModel.errorDismissButtonTitle.title,
             isButtonRetryEnabled: viewModel.getIsRetryEnabled()
         )
         .accessibilityIdentifier(tags.errorView)

--- a/Sources/RozetkaPaySDK/View/TokenizationFormView.swift
+++ b/Sources/RozetkaPaySDK/View/TokenizationFormView.swift
@@ -84,11 +84,12 @@ private extension TokenizationFormView {
             themeConfigurator: viewModel.themeConfigurator,
             errorMessage: viewModel.errorMessage,
             onCancel: {
-                viewModel.cancelled()
+                viewModel.failed()
             },
             onRetry: {
                 viewModel.retryLoading()
             },
+            cancelButtonTitle: viewModel.errorDismissButtonTitle.title,
             isExpanded: true
         )
         .accessibilityIdentifier(tags.errorView)

--- a/Sources/RozetkaPaySDK/View/TokenizationView.swift
+++ b/Sources/RozetkaPaySDK/View/TokenizationView.swift
@@ -126,11 +126,12 @@ private extension TokenizationView {
             themeConfigurator: viewModel.themeConfigurator,
             errorMessage: viewModel.errorMessage,
             onCancel: {
-                viewModel.cancelled()
+                viewModel.failed()
             },
             onRetry: {
                 viewModel.retryLoading()
-            }
+            },
+            cancelButtonTitle: viewModel.errorDismissButtonTitle.title
         )
         .accessibilityIdentifier(tags.errorView)
         .padding()

--- a/Sources/RozetkaPaySDK/ViewModel/BaseViewModel.swift
+++ b/Sources/RozetkaPaySDK/ViewModel/BaseViewModel.swift
@@ -15,6 +15,7 @@ class BaseViewModel: ObservableObject {
     let viewParameters: ViewParametersProtocol
     let themeConfigurator: RozetkaPayThemeConfigurator
     let provideCardPaymentSystemUseCase: ProvideCardPaymentSystemUseCase
+    let errorDismissButtonTitle: ErrorDismissButtonTitle
     
     //MARK: - UI Properties
     @Published var alertItem: CustomAlertItem?
@@ -46,12 +47,14 @@ class BaseViewModel: ObservableObject {
         client: ClientAuthParametersProtocol,
         viewParameters: ViewParametersProtocol,
         themeConfigurator: RozetkaPayThemeConfigurator,
-        provideCardPaymentSystemUseCase: ProvideCardPaymentSystemUseCase
+        provideCardPaymentSystemUseCase: ProvideCardPaymentSystemUseCase,
+        errorDismissButtonTitle: ErrorDismissButtonTitle = .close
     ) {
         self.client = client
         self.viewParameters = viewParameters
         self.themeConfigurator = themeConfigurator
         self.provideCardPaymentSystemUseCase = provideCardPaymentSystemUseCase
+        self.errorDismissButtonTitle = errorDismissButtonTitle
         self.didPerformInitialValidation = false
     }
     

--- a/Sources/RozetkaPaySDK/ViewModel/PayViewModel.swift
+++ b/Sources/RozetkaPaySDK/ViewModel/PayViewModel.swift
@@ -54,6 +54,8 @@ final class PayViewModel:  BaseViewModel {
     
     private let isNeedToReturnTokenizationCard: Bool
     private let isAllowApplePay: Bool
+
+    private var lastError: PaymentError?
     
     private let amountWithCurrencyStr: String
     
@@ -98,7 +100,8 @@ final class PayViewModel:  BaseViewModel {
             client: parameters.client,
             viewParameters: parameters.viewParameters,
             themeConfigurator: parameters.themeConfigurator,
-            provideCardPaymentSystemUseCase: provideCardPaymentSystemUseCase ?? ProvideCardPaymentSystemUseCase()
+            provideCardPaymentSystemUseCase: provideCardPaymentSystemUseCase ?? ProvideCardPaymentSystemUseCase(),
+            errorDismissButtonTitle: parameters.errorDismissButtonTitle
         )
         
         checkIsNeedToPayByTokenizedCard()
@@ -137,7 +140,8 @@ final class PayViewModel:  BaseViewModel {
             client: parameters.client,
             viewParameters: parameters.viewParameters,
             themeConfigurator: parameters.themeConfigurator,
-            provideCardPaymentSystemUseCase: provideCardPaymentSystemUseCase ?? ProvideCardPaymentSystemUseCase()
+            provideCardPaymentSystemUseCase: provideCardPaymentSystemUseCase ?? ProvideCardPaymentSystemUseCase(),
+            errorDismissButtonTitle: parameters.errorDismissButtonTitle
         )
         
         checkIsNeedToPayByTokenizedCard()
@@ -186,6 +190,34 @@ extension PayViewModel {
             deliverBatch(
                 .cancelled(
                     batchExternalId: externalId
+                )
+            )
+        }
+    }
+
+    func failed() {
+        stopLoader()
+        clearError()
+        isThreeDSConfirmationPresented = false
+        threeDSModel = nil
+
+        let error = lastError ?? PaymentError(
+            code: nil,
+            message: errorMessage,
+            externalId: externalId
+        )
+
+        switch initialMode {
+        case .single:
+            deliver(
+                .failed(error: error)
+            )
+        case .batch:
+            deliverBatch(
+                .failed(
+                    batchExternalId: externalId,
+                    error: error,
+                    ordersPayments: nil
                 )
             )
         }
@@ -279,16 +311,9 @@ extension PayViewModel {
                 case let .success(_, token):
                     self.createPayment(fromApplePay: token)
                 case let .cancelled(externalId):
-                    self.processPaymentResult(
-                        .cancelled(
-                            externalId: externalId,
-                            paymentId: nil
-                        )
-                    )
+                    self.handlePrePaymentCancelled(externalId: externalId)
                 case let .failed(error):
-                    self.processPaymentResult(
-                        .failed(error: error)
-                    )
+                    self.handlePrePaymentFailed(error)
                 }
             }
         }
@@ -337,16 +362,9 @@ extension PayViewModel {
                     case .complete(let successModel):
                         self.createPayment(from: successModel)
                     case .failed(let error):
-                        self.processPaymentResult(
-                            error.convertToCreatePaymentResult(self.externalId)
-                        )
+                        self.handleTokenizationFailed(error)
                     case .cancelled:
-                        self.processPaymentResult(
-                            .cancelled(
-                                externalId: self.externalId,
-                                paymentId: nil
-                            )
-                        )
+                        self.handlePrePaymentCancelled(externalId: self.externalId)
                     }
                 }
             }
@@ -361,6 +379,11 @@ private extension PayViewModel {
         setError(message)
         isThreeDSConfirmationPresented = false
         threeDSModel = nil
+    }
+
+    func showError(_ error: PaymentError) {
+        lastError = error
+        showError(error.localizedDescription)
     }
     
     func createPayment(from model: TokenizedCard) {
@@ -419,8 +442,49 @@ private extension PayViewModel {
         }
     }
     
-    
-    func processPaymentResult(_ result: CreatePaymentResult,_ tokenizedCard: TokenizedCard? = nil) {
+    func handlePrePaymentCancelled(externalId: String?) {
+        switch initialMode {
+        case .single:
+            processPaymentResult(
+                .cancelled(externalId: externalId, paymentId: nil)
+            )
+        case .batch:
+            processBatchPaymentResult(
+                .cancelled(batchExternalId: externalId)
+            )
+        }
+    }
+
+    func handlePrePaymentFailed(_ error: PaymentError) {
+        switch initialMode {
+        case .single:
+            processPaymentResult(
+                .failed(error: error)
+            )
+        case .batch:
+            processBatchPaymentResult(
+                .failed(
+                    batchExternalId: externalId,
+                    error: error
+                )
+            )
+        }
+    }
+
+    func handleTokenizationFailed(_ error: TokenizationError) {
+        switch initialMode {
+        case .single:
+            processPaymentResult(
+                error.convertToCreatePaymentResult(externalId)
+            )
+        case .batch:
+            processBatchPaymentResult(
+                error.convertToCreateBatchPaymentResult(externalId)
+            )
+        }
+    }
+
+    func processPaymentResult(_ result: CreatePaymentResult, _ tokenizedCard: TokenizedCard? = nil) {
         resetState()
         stopLoader()
 
@@ -455,11 +519,11 @@ private extension PayViewModel {
                 deliver(.failed(error: error))
                 return
             }
-            showError(error.localizedDescription)
+            showError(error)
         }
     }
 
-    func processBatchPaymentResult(_ result: CreateBatchPaymentResult, _ tokenizedCard: TokenizedCard?) {
+    func processBatchPaymentResult(_ result: CreateBatchPaymentResult, _ tokenizedCard: TokenizedCard? = nil) {
         resetState()
         stopLoader()
 
@@ -496,7 +560,7 @@ private extension PayViewModel {
                 )
                 return
             }
-            showError(error.localizedDescription)
+            showError(error)
         }
     }
 
@@ -535,7 +599,7 @@ extension PayViewModel {
                             self.deliver(.failed(error: error))
                             return
                         }
-                        self.setError(error.localizedDescription)
+                        self.showError(error)
                     default:
                         self.deliver(result)
                     }
@@ -581,7 +645,7 @@ extension PayViewModel {
                             )
                             return
                         }
-                        self.setError(error.localizedDescription)
+                        self.showError(error)
                     default:
                         self.deliverBatch(result)
                     }

--- a/Sources/RozetkaPaySDK/ViewModel/TokenizationFormViewModel.swift
+++ b/Sources/RozetkaPaySDK/ViewModel/TokenizationFormViewModel.swift
@@ -12,6 +12,9 @@ final class TokenizationFormViewModel: BaseViewModel {
     //MARK: - Properties
     private let onResultCallback: (TokenizationFormResultCompletionHandler)?
     private let stateUICallback: (TokenizationFormUIStateCompletionHandler)?
+
+    /// Last tokenization error shown on the error screen, used to deliver `.failed` when the user taps "Close".
+    private var lastError: TokenizationError?
     
     //MARK: - Init
     init(
@@ -26,7 +29,8 @@ final class TokenizationFormViewModel: BaseViewModel {
             client: parameters.client,
             viewParameters: parameters.viewParameters,
             themeConfigurator: parameters.themeConfigurator,
-            provideCardPaymentSystemUseCase: provideCardPaymentSystemUseCase ?? ProvideCardPaymentSystemUseCase()
+            provideCardPaymentSystemUseCase: provideCardPaymentSystemUseCase ?? ProvideCardPaymentSystemUseCase(),
+            errorDismissButtonTitle: parameters.errorDismissButtonTitle
         )
         
         setTestData()
@@ -73,7 +77,20 @@ extension TokenizationFormViewModel {
             .cancelled
         )
     }
-    
+
+    func failed() {
+        resetState()
+        stopLoader()
+        stateUICallback?(
+            .stopLoading
+        )
+
+        let error = lastError ?? .failed(message: errorMessage, errorDescription: nil)
+        onResultCallback?(
+            .failed(error: error)
+        )
+    }
+
     func resetState() {
         clearError()
     }
@@ -106,6 +123,7 @@ private extension TokenizationFormViewModel {
                     case .cancelled:
                         self.cancelled()
                     case let .failed(message, _):
+                        self.lastError = error
                         self.setError(message)
                         self.onResultCallback?(
                             .failed(error: error)

--- a/Sources/RozetkaPaySDK/ViewModel/TokenizationViewModel.swift
+++ b/Sources/RozetkaPaySDK/ViewModel/TokenizationViewModel.swift
@@ -18,6 +18,9 @@ final class TokenizationViewModel: BaseViewModel {
     //MARK: - Properties
     private let onResultCallback: (TokenizationResultCompletionHandler)?
     private var hasDeliveredResult = false
+
+    /// Last tokenization error shown on the error screen, used to deliver `.failed` when the user taps "Close".
+    private var lastError: TokenizationError?
     
     //MARK: - Init
     init(
@@ -30,7 +33,8 @@ final class TokenizationViewModel: BaseViewModel {
             client: parameters.client,
             viewParameters: parameters.viewParameters,
             themeConfigurator: parameters.themeConfigurator,
-            provideCardPaymentSystemUseCase: provideCardPaymentSystemUseCase ?? ProvideCardPaymentSystemUseCase()
+            provideCardPaymentSystemUseCase: provideCardPaymentSystemUseCase ?? ProvideCardPaymentSystemUseCase(),
+            errorDismissButtonTitle: parameters.errorDismissButtonTitle
         )
         
         setTestData()
@@ -71,6 +75,15 @@ extension TokenizationViewModel {
         deliver(.cancelled)
     }
 
+    /// Delivers a `.failed` result. Triggered when the user taps the "Close" button on the error screen.
+    func failed() {
+        resetState()
+        stopLoader()
+
+        let error = lastError ?? .failed(message: errorMessage, errorDescription: nil)
+        deliver(.failed(error: error))
+    }
+
     func handleViewDisappeared() {
         guard !hasDeliveredResult else { return }
         cancelled()
@@ -108,6 +121,7 @@ private extension TokenizationViewModel {
                     case .cancelled:
                         self.cancelled()
                     case let .failed(message, _):
+                        self.lastError = error
                         self.setError(message)
                     }
                 case .cancelled:


### PR DESCRIPTION
- Error screen now delivers a `.failed` result instead of `.cancelled` when dismissed: add `failed()` to Pay/Tokenization/TokenizationForm view models, tracking the `lastError` to surface a meaningful error.
- Add `ErrorDismissButtonTitle` enum (`.cancel` / `.close` / `.custom`) exposed through `PaymentParameters`, `BatchPaymentParameters`, `TokenizationParameters` and `TokenizationFormParameters`; threaded into `BaseViewModel` so `ErrorView` renders the chosen label.
- Route pre-payment and tokenization failures through dedicated `handlePrePaymentCancelled` / `handlePrePaymentFailed` / `handleTokenizationFailed` helpers that respect single vs. batch mode.
- Add `TokenizationError.convertToCreateBatchPaymentResult` and let `processBatchPaymentResult` default its `tokenizedCard` argument.
- Add `rozetka_pay_common_button_close` string (en/uk).